### PR TITLE
Removing broken boolean logic

### DIFF
--- a/test/integration/__snapshots__/compute-depgraph.spec.ts.snap
+++ b/test/integration/__snapshots__/compute-depgraph.spec.ts.snap
@@ -1,0 +1,204 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`compute-depgraph should successfully create snyk dep graph from swift-pm dep tree 1`] = `
+Object {
+  "graph": Object {
+    "nodes": Array [
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "github.com/grpc/grpc-swift@1.16.0",
+          },
+        ],
+        "nodeId": "root-node",
+        "pkgId": "swiftPM-spike@unspecified",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "github.com/apple/swift-nio@2.53.0",
+          },
+          Object {
+            "nodeId": "github.com/apple/swift-nio-http2@1.26.0",
+          },
+          Object {
+            "nodeId": "github.com/apple/swift-nio-transport-services@1.17.0",
+          },
+          Object {
+            "nodeId": "github.com/apple/swift-nio-extras@1.19.0",
+          },
+          Object {
+            "nodeId": "github.com/apple/swift-protobuf@1.21.0",
+          },
+          Object {
+            "nodeId": "github.com/apple/swift-log@1.5.2",
+          },
+          Object {
+            "nodeId": "github.com/apple/swift-nio-ssl@2.24.0",
+          },
+        ],
+        "nodeId": "github.com/grpc/grpc-swift@1.16.0",
+        "pkgId": "github.com/grpc/grpc-swift@1.16.0",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "github.com/apple/swift-atomics@1.1.0",
+          },
+          Object {
+            "nodeId": "github.com/apple/swift-collections@1.0.4",
+          },
+        ],
+        "nodeId": "github.com/apple/swift-nio@2.53.0",
+        "pkgId": "github.com/apple/swift-nio@2.53.0",
+      },
+      Object {
+        "deps": Array [],
+        "nodeId": "github.com/apple/swift-atomics@1.1.0",
+        "pkgId": "github.com/apple/swift-atomics@1.1.0",
+      },
+      Object {
+        "deps": Array [],
+        "nodeId": "github.com/apple/swift-collections@1.0.4",
+        "pkgId": "github.com/apple/swift-collections@1.0.4",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "github.com/apple/swift-nio@2.53.0",
+          },
+          Object {
+            "nodeId": "github.com/apple/swift-atomics@1.1.0",
+          },
+        ],
+        "nodeId": "github.com/apple/swift-nio-http2@1.26.0",
+        "pkgId": "github.com/apple/swift-nio-http2@1.26.0",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "github.com/apple/swift-nio@2.53.0",
+          },
+          Object {
+            "nodeId": "github.com/apple/swift-atomics@1.1.0",
+          },
+        ],
+        "nodeId": "github.com/apple/swift-nio-transport-services@1.17.0",
+        "pkgId": "github.com/apple/swift-nio-transport-services@1.17.0",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "github.com/apple/swift-nio@2.53.0",
+          },
+        ],
+        "nodeId": "github.com/apple/swift-nio-extras@1.19.0",
+        "pkgId": "github.com/apple/swift-nio-extras@1.19.0",
+      },
+      Object {
+        "deps": Array [],
+        "nodeId": "github.com/apple/swift-protobuf@1.21.0",
+        "pkgId": "github.com/apple/swift-protobuf@1.21.0",
+      },
+      Object {
+        "deps": Array [],
+        "nodeId": "github.com/apple/swift-log@1.5.2",
+        "pkgId": "github.com/apple/swift-log@1.5.2",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "github.com/apple/swift-nio@2.53.0",
+          },
+        ],
+        "nodeId": "github.com/apple/swift-nio-ssl@2.24.0",
+        "pkgId": "github.com/apple/swift-nio-ssl@2.24.0",
+      },
+    ],
+    "rootNodeId": "root-node",
+  },
+  "pkgManager": Object {
+    "name": "swift",
+  },
+  "pkgs": Array [
+    Object {
+      "id": "swiftPM-spike@unspecified",
+      "info": Object {
+        "name": "swiftPM-spike",
+        "version": "unspecified",
+      },
+    },
+    Object {
+      "id": "github.com/grpc/grpc-swift@1.16.0",
+      "info": Object {
+        "name": "github.com/grpc/grpc-swift",
+        "version": "1.16.0",
+      },
+    },
+    Object {
+      "id": "github.com/apple/swift-nio@2.53.0",
+      "info": Object {
+        "name": "github.com/apple/swift-nio",
+        "version": "2.53.0",
+      },
+    },
+    Object {
+      "id": "github.com/apple/swift-atomics@1.1.0",
+      "info": Object {
+        "name": "github.com/apple/swift-atomics",
+        "version": "1.1.0",
+      },
+    },
+    Object {
+      "id": "github.com/apple/swift-collections@1.0.4",
+      "info": Object {
+        "name": "github.com/apple/swift-collections",
+        "version": "1.0.4",
+      },
+    },
+    Object {
+      "id": "github.com/apple/swift-nio-http2@1.26.0",
+      "info": Object {
+        "name": "github.com/apple/swift-nio-http2",
+        "version": "1.26.0",
+      },
+    },
+    Object {
+      "id": "github.com/apple/swift-nio-transport-services@1.17.0",
+      "info": Object {
+        "name": "github.com/apple/swift-nio-transport-services",
+        "version": "1.17.0",
+      },
+    },
+    Object {
+      "id": "github.com/apple/swift-nio-extras@1.19.0",
+      "info": Object {
+        "name": "github.com/apple/swift-nio-extras",
+        "version": "1.19.0",
+      },
+    },
+    Object {
+      "id": "github.com/apple/swift-protobuf@1.21.0",
+      "info": Object {
+        "name": "github.com/apple/swift-protobuf",
+        "version": "1.21.0",
+      },
+    },
+    Object {
+      "id": "github.com/apple/swift-log@1.5.2",
+      "info": Object {
+        "name": "github.com/apple/swift-log",
+        "version": "1.5.2",
+      },
+    },
+    Object {
+      "id": "github.com/apple/swift-nio-ssl@2.24.0",
+      "info": Object {
+        "name": "github.com/apple/swift-nio-ssl",
+        "version": "2.24.0",
+      },
+    },
+  ],
+  "schemaVersion": "1.3.0",
+}
+`;

--- a/test/integration/compute-depgraph.spec.ts
+++ b/test/integration/compute-depgraph.spec.ts
@@ -1,0 +1,15 @@
+import { computeDepGraph } from '../../lib/compute-depgraph';
+import * as path from 'path';
+
+describe('compute-depgraph', () => {
+  // Run locally for verifications. Or even better, add OSX runner to CircleCI and run it there as well.
+  it.skip('should successfully create snyk dep graph from swift-pm dep tree', async () => {
+    const targetFile = path.join(__dirname, '../fixtures/Package.swift');
+    const result = await computeDepGraph(
+      path.join(__dirname, '../fixtures'),
+      targetFile,
+    );
+
+    expect(result).toMatchSnapshot();
+  }, 100000);
+});

--- a/test/unit/compute-depgraph.spec.ts
+++ b/test/unit/compute-depgraph.spec.ts
@@ -2,7 +2,6 @@ import { computeDepGraph } from '../../lib/compute-depgraph';
 import { execute } from '../../lib/subprocess';
 import { dependencies } from '../fixtures/dependencies';
 import * as path from 'path';
-import * as fs from 'fs';
 
 jest.setTimeout(100000);
 jest.mock('../../lib/subprocess');
@@ -79,40 +78,5 @@ describe('compute-depgraph', () => {
 
     const swiftArguments = mockedExecute.mock.calls[0][1];
     expect(swiftArguments.length).toEqual(SWIFT_DEFAULT_PARAMETERS_COUNT);
-  });
-
-  describe('Generated files logic', () => {
-    it('should delete the .build folder or Package.resolved if it they do not exist already', async () => {
-      const mockedFs = jest.mocked(fs, true);
-      mockedFs.statSync.mockImplementationOnce(() => {
-        throw new Error('Test Error');
-      });
-      mockedFs.statSync.mockImplementationOnce(() => {
-        throw new Error('Test Error');
-      });
-      const mockedStat = {
-        isDirectory: jest.fn(),
-        isFile: jest.fn(),
-      };
-      mockedFs.lstatSync.mockReturnValue(mockedStat as unknown as fs.Stats);
-      mockedStat.isDirectory.mockReturnValue(true);
-      mockedStat.isFile.mockReturnValue(true);
-      await computeDepGraph('.', 'Package.swift');
-      expect(mockedFs.rmdirSync).toHaveBeenCalledWith('.build');
-      expect(mockedFs.unlinkSync).toHaveBeenCalledWith('Package.resolved');
-    });
-
-    it('should not delete the .build folder or Package.resolved if it they already exist', async () => {
-      const mockedFs = jest.mocked(fs, true);
-      const mockedStat = {
-        isDirectory: jest.fn(),
-        isFile: jest.fn(),
-      };
-      mockedFs.lstatSync.mockReturnValue(mockedStat as unknown as fs.Stats);
-      mockedStat.isDirectory.mockReturnValue(true);
-      mockedStat.isFile.mockReturnValue(true);
-      await computeDepGraph('.', 'Package.swift');
-      expect(mockedFs.unlinkSync).not.toHaveBeenCalled();
-    });
   });
 });

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -26,6 +26,7 @@ describe('inspect', () => {
     );
     expect(result).toMatchSnapshot();
   });
+
   it('should reject invalid manifest', async () => {
     const mockedLookpath = jest.mocked(lookpath);
     const mockedComputeDepGraph = jest.mocked(computeDepGraph);
@@ -37,6 +38,7 @@ describe('inspect', () => {
       'manifest.swift is not supported by Swift Package Manager. Please provide with path to Package.swift',
     );
   });
+
   it('should check for swift binary', async () => {
     const mockedLookpath = jest.mocked(lookpath);
     const mockedComputeDepGraph = jest.mocked(computeDepGraph);


### PR DESCRIPTION
The logic for deleting generated files was broken. E.g.

https://github.com/snyk/snyk-swiftpm-plugin/blob/9b14bffa73335a2ec35883633d052db017585361/lib/compute-depgraph.ts#L18-L25

Would always return true no matter if a file existed or not. Further, the logic required a CWD which was not guaranteed. Files were never deleted.

We've agreed that we should not delete generated files at all, as they are generated by the `swift` CLI tool itself, and it is unpredictable if the file existed before we were run or not.