### PR TITLE
fix: ensure that the proxy env vars is passed on

### DIFF
--- a/lib/subprocess.ts
+++ b/lib/subprocess.ts
@@ -6,13 +6,32 @@ interface ProcessOptions {
 }
 
 function makeSpawnOptions(options?: ProcessOptions) {
-  const spawnOptions: SpawnOptions = { shell: false };
-  if (options && options.cwd) {
+  const spawnOptions: SpawnOptions = {
+    shell: false,
+    env: { ...process.env },
+  };
+  if (options?.cwd) {
     spawnOptions.cwd = options.cwd;
   }
-  if (options && options.env) {
-    spawnOptions.env = options.env;
+
+  if (options?.env) {
+    spawnOptions.env = { ...spawnOptions.env, ...options.env };
+  } else {
+    spawnOptions.env = { ...spawnOptions.env };
   }
+
+  // Before spawning an external process, we check if we need to
+  // restore the system proxy configuration, which overrides the CLI internal proxy configuration.
+  if (process.env.SNYK_SYSTEM_HTTP_PROXY !== undefined) {
+    spawnOptions.env.HTTP_PROXY = process.env.SNYK_SYSTEM_HTTP_PROXY;
+  }
+  if (process.env.SNYK_SYSTEM_HTTPS_PROXY !== undefined) {
+    spawnOptions.env.HTTPS_PROXY = process.env.SNYK_SYSTEM_HTTPS_PROXY;
+  }
+  if (process.env.SNYK_SYSTEM_NO_PROXY !== undefined) {
+    spawnOptions.env.NO_PROXY = process.env.SNYK_SYSTEM_NO_PROXY;
+  }
+
   return spawnOptions;
 }
 


### PR DESCRIPTION
From the Slack discussion:

> There is a bigger architectural change in the Extensible CLI.

> The Extensible CLI spawns a network proxy (which intercepts the SSL connections) and channels all the traffic from the legacy CLI through that internal proxy. The Intention is to add support for different features like Kerberos Proxy Authentication, OS CA stores, OAuth … through the Golang based Extensible CLI to the legacy CLI. This happens by setting the proxy settings when calling the legacy CLI from within the Extensible CLI. When the legacy CLI now calls an external tool, this tool would also try to communicate through the internal proxy. Since the internal proxy intercepts SSL connections, it uses a self-signed CA cert, which is known to the legacy CLI but not the external tools it calls.
There are actually different solutions.

> Using the solution we applied in the [snyk-go-plugin](https://github.com/snyk/snyk-go-plugin/blob/master/lib/sub-process.ts#L22) and others, which restores the proxy settings to whatever the user specified.

> Telling the external tool to accept the temporary certificate file used by the internal proxy.