### PR TITLE
fix: resolve registry identity URLs to github.com package paths (OSM-3567)

### DIFF
--- a/lib/compute-depgraph.ts
+++ b/lib/compute-depgraph.ts
@@ -4,12 +4,31 @@ import * as path from 'path';
 import { SwiftError } from './errors';
 
 export type DepTreeNode = {
+  identity?: string;
   name: string;
   url: string;
   version: string;
   path: string;
   dependencies: DepTreeNode[];
 };
+
+// Matches Swift Package Registry identity format: scope.package-name
+// e.g. "apple.swift-argument-parser" → github.com/apple/swift-argument-parser
+const REGISTRY_IDENTITY_RE = /^[a-zA-Z0-9][a-zA-Z0-9-]*\.[a-zA-Z0-9][a-zA-Z0-9-]*$/;
+
+function packageNameFromUrl(url: string): string {
+  if (url.startsWith('https://') || url.startsWith('http://')) {
+    return url
+      .replace(/https:\/\//g, '')
+      .replace(/http:\/\//g, '')
+      .replace(/.git/g, '');
+  }
+  if (REGISTRY_IDENTITY_RE.test(url)) {
+    const dotIndex = url.indexOf('.');
+    return `github.com/${url.slice(0, dotIndex)}/${url.slice(dotIndex + 1)}`;
+  }
+  return url;
+}
 
 function traverseTree(
   rootNode: DepTreeNode,
@@ -20,16 +39,8 @@ function traverseTree(
 
   childNodes?.forEach((node) => {
     const { url, version } = node;
-    const name = url
-      .replace(/https:\/\//g, '')
-      .replace(/http:\/\//g, '')
-      .replace(/.git/g, '');
-    const parentName =
-      rootNodeId ||
-      rootNode.url
-        .replace(/https:\/\//g, '')
-        .replace(/http:\/\//g, '')
-        .replace(/.git/g, '');
+    const name = packageNameFromUrl(url);
+    const parentName = rootNodeId || packageNameFromUrl(rootNode.url);
 
     const nodeId = `${name}@${version}`;
     const parentNodeId = `${parentName}@${rootNode.version}`;

--- a/test/fixtures/dependencies.ts
+++ b/test/fixtures/dependencies.ts
@@ -1,3 +1,38 @@
+export const dependenciesWithRegistryIdentity = {
+  identity: 'swift-goof',
+  name: 'swiftPM-spike',
+  url: '/Users/user/swift/swift-goof',
+  version: 'unspecified',
+  path: '/Users/user/swift/swift-goof',
+  dependencies: [
+    {
+      identity: 'apple.swift-argument-parser',
+      name: 'swift-argument-parser',
+      url: 'apple.swift-argument-parser',
+      version: '1.2.0',
+      path: '/Users/user/swift/swift-goof/.build/checkouts/swift-argument-parser',
+      dependencies: [],
+    },
+    {
+      identity: 'apple.swift-nio',
+      name: 'swift-nio',
+      url: 'apple.swift-nio',
+      version: '2.42.0',
+      path: '/Users/user/swift/swift-goof/.build/checkouts/swift-nio',
+      dependencies: [
+        {
+          identity: 'apple.swift-atomics',
+          name: 'swift-atomics',
+          url: 'apple.swift-atomics',
+          version: '1.0.2',
+          path: '/Users/user/swift/swift-goof/.build/checkouts/swift-atomics',
+          dependencies: [],
+        },
+      ],
+    },
+  ],
+};
+
 export const dependencies = {
   identity: 'swift-goof',
   name: 'swiftPM-spike',

--- a/test/unit/__snapshots__/compute-depgraph.spec.ts.snap
+++ b/test/unit/__snapshots__/compute-depgraph.spec.ts.snap
@@ -1,5 +1,80 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`compute-depgraph should convert registry identity URLs (scope.package-name) to github.com paths 1`] = `
+{
+  "graph": {
+    "nodes": [
+      {
+        "deps": [
+          {
+            "nodeId": "github.com/apple/swift-argument-parser@1.2.0",
+          },
+          {
+            "nodeId": "github.com/apple/swift-nio@2.42.0",
+          },
+        ],
+        "nodeId": "root-node",
+        "pkgId": "swiftPM-spike@unspecified",
+      },
+      {
+        "deps": [],
+        "nodeId": "github.com/apple/swift-argument-parser@1.2.0",
+        "pkgId": "github.com/apple/swift-argument-parser@1.2.0",
+      },
+      {
+        "deps": [
+          {
+            "nodeId": "github.com/apple/swift-atomics@1.0.2",
+          },
+        ],
+        "nodeId": "github.com/apple/swift-nio@2.42.0",
+        "pkgId": "github.com/apple/swift-nio@2.42.0",
+      },
+      {
+        "deps": [],
+        "nodeId": "github.com/apple/swift-atomics@1.0.2",
+        "pkgId": "github.com/apple/swift-atomics@1.0.2",
+      },
+    ],
+    "rootNodeId": "root-node",
+  },
+  "pkgManager": {
+    "name": "swift",
+  },
+  "pkgs": [
+    {
+      "id": "swiftPM-spike@unspecified",
+      "info": {
+        "name": "swiftPM-spike",
+        "version": "unspecified",
+      },
+    },
+    {
+      "id": "github.com/apple/swift-argument-parser@1.2.0",
+      "info": {
+        "name": "github.com/apple/swift-argument-parser",
+        "version": "1.2.0",
+      },
+    },
+    {
+      "id": "github.com/apple/swift-nio@2.42.0",
+      "info": {
+        "name": "github.com/apple/swift-nio",
+        "version": "2.42.0",
+      },
+    },
+    {
+      "id": "github.com/apple/swift-atomics@1.0.2",
+      "info": {
+        "name": "github.com/apple/swift-atomics",
+        "version": "1.0.2",
+      },
+    },
+  ],
+  "schemaVersion": "1.3.0",
+}
+`;
+
 exports[`compute-depgraph should successfully create snyk dep graph from swift-pm dep tree 1`] = `
 {
   "graph": {

--- a/test/unit/compute-depgraph.spec.ts
+++ b/test/unit/compute-depgraph.spec.ts
@@ -1,6 +1,9 @@
 import { computeDepGraph } from '../../lib/compute-depgraph';
 import { execute } from '../../lib/subprocess';
-import { dependencies } from '../fixtures/dependencies';
+import {
+  dependencies,
+  dependenciesWithRegistryIdentity,
+} from '../fixtures/dependencies';
 import * as path from 'path';
 
 jest.setTimeout(100000);
@@ -22,6 +25,18 @@ describe('compute-depgraph', () => {
       targetFile,
     );
 
+    expect(result).toMatchSnapshot();
+  });
+
+  it('should convert registry identity URLs (scope.package-name) to github.com paths', async () => {
+    mockedExecute.mockResolvedValueOnce(
+      JSON.stringify(dependenciesWithRegistryIdentity),
+    );
+    const targetFile = path.join(__dirname, '../fixtures/Package.swift');
+    const result = await computeDepGraph(
+      path.join(__dirname, '../fixtures'),
+      targetFile,
+    );
     expect(result).toMatchSnapshot();
   });
 


### PR DESCRIPTION
## Summary

- When `--replace-scm-with-registry` is in use, Swift sets the `url` field to a registry identity (e.g. `apple.swift-argument-parser`) rather than the SCM URL
- The previous logic stripped `https://` and `.git` — leaving `apple.swift-argument-parser` unchanged, which produces no vuln DB hit
- This PR extracts a `packageNameFromUrl` helper that detects `scope.package-name` format and maps it to `github.com/scope/package-name` before building the dep-graph

## Root cause

`traverseTree` in `compute-depgraph.ts` derived package names solely by stripping URL scheme and `.git` suffix. Registry identities have neither, so they passed through untransformed.

## Changes

- `lib/compute-depgraph.ts` — new `packageNameFromUrl` helper with three cases: https/http URL (existing behaviour), registry identity (`scope.package-name` → `github.com/scope/package-name`), and local paths (returned as-is)
- `test/fixtures/dependencies.ts` — new `dependenciesWithRegistryIdentity` fixture with `scope.package-name` URLs
- `test/unit/compute-depgraph.spec.ts` — new test case covering registry identity conversion
- `test/unit/__snapshots__/compute-depgraph.spec.ts.snap` — snapshot for new test, confirming `apple.swift-argument-parser` → `github.com/apple/swift-argument-parser`

## Test plan

- [ ] `npx jest test/unit` — all 8 tests pass
- [ ] Manually verify with a project using `--replace-scm-with-registry` that registry-sourced packages now appear in vuln results

🤖 Generated with [Claude Code](https://claude.com/claude-code)