### PR TITLE
fix: resolve registry identity URLs to github.com package paths (OSM-3567)

### DIFF
--- a/lib/compute-depgraph.ts
+++ b/lib/compute-depgraph.ts
@@ -4,12 +4,31 @@ import * as path from 'path';
 import { SwiftError } from './errors';
 
 export type DepTreeNode = {
+  identity?: string;
   name: string;
   url: string;
   version: string;
   path: string;
   dependencies: DepTreeNode[];
 };
+
+// Matches Swift Package Registry identity format: scope.package-name
+// e.g. "apple.swift-argument-parser" → github.com/apple/swift-argument-parser
+const REGISTRY_IDENTITY_RE = /^[a-zA-Z0-9][a-zA-Z0-9-]*\.[a-zA-Z0-9][a-zA-Z0-9-]*$/;
+
+function packageNameFromUrl(url: string): string {
+  if (url.startsWith('https://') || url.startsWith('http://')) {
+    return url
+      .replace(/https:\/\//g, '')
+      .replace(/http:\/\//g, '')
+      .replace(/.git/g, '');
+  }
+  if (REGISTRY_IDENTITY_RE.test(url)) {
+    const dotIndex = url.indexOf('.');
+    return `github.com/${url.slice(0, dotIndex)}/${url.slice(dotIndex + 1)}`;
+  }
+  return url;
+}
 
 function traverseTree(
   rootNode: DepTreeNode,
@@ -20,16 +39,8 @@ function traverseTree(
 
   childNodes?.forEach((node) => {
     const { url, version } = node;
-    const name = url
-      .replace(/https:\/\//g, '')
-      .replace(/http:\/\//g, '')
-      .replace(/.git/g, '');
-    const parentName =
-      rootNodeId ||
-      rootNode.url
-        .replace(/https:\/\//g, '')
-        .replace(/http:\/\//g, '')
-        .replace(/.git/g, '');
+    const name = packageNameFromUrl(url);
+    const parentName = rootNodeId || packageNameFromUrl(rootNode.url);
 
     const nodeId = `${name}@${version}`;
     const parentNodeId = `${parentName}@${rootNode.version}`;

--- a/lib/compute-depgraph.ts
+++ b/lib/compute-depgraph.ts
@@ -16,12 +16,12 @@ export type DepTreeNode = {
 // e.g. "apple.swift-argument-parser" → github.com/apple/swift-argument-parser
 const REGISTRY_IDENTITY_RE = /^[a-zA-Z0-9][a-zA-Z0-9-]*\.[a-zA-Z0-9][a-zA-Z0-9-]*$/;
 
-function packageNameFromUrl(url: string): string {
+export function packageNameFromUrl(url: string): string {
   if (url.startsWith('https://') || url.startsWith('http://')) {
     return url
       .replace(/https:\/\//g, '')
       .replace(/http:\/\//g, '')
-      .replace(/.git/g, '');
+      .replace(/\.git$/g, '');
   }
   if (REGISTRY_IDENTITY_RE.test(url)) {
     const dotIndex = url.indexOf('.');

--- a/test/fixtures/dependencies.ts
+++ b/test/fixtures/dependencies.ts
@@ -1,3 +1,29 @@
+export const dependenciesWithMixedSources = {
+  identity: 'swift-goof',
+  name: 'swiftPM-spike',
+  url: '/Users/user/swift/swift-goof',
+  version: 'unspecified',
+  path: '/Users/user/swift/swift-goof',
+  dependencies: [
+    {
+      identity: 'grpc-swift',
+      name: 'grpc-swift',
+      url: 'https://github.com/grpc/grpc-swift.git',
+      version: '1.11.0',
+      path: '/Users/user/swift/swift-goof/.build/checkouts/grpc-swift',
+      dependencies: [],
+    },
+    {
+      identity: 'apple.swift-argument-parser',
+      name: 'swift-argument-parser',
+      url: 'apple.swift-argument-parser',
+      version: '1.2.0',
+      path: '/Users/user/swift/swift-goof/.build/checkouts/swift-argument-parser',
+      dependencies: [],
+    },
+  ],
+};
+
 export const dependenciesWithRegistryIdentity = {
   identity: 'swift-goof',
   name: 'swiftPM-spike',

--- a/test/fixtures/dependencies.ts
+++ b/test/fixtures/dependencies.ts
@@ -1,3 +1,38 @@
+export const dependenciesWithRegistryIdentity = {
+  identity: 'swift-goof',
+  name: 'swiftPM-spike',
+  url: '/Users/user/swift/swift-goof',
+  version: 'unspecified',
+  path: '/Users/user/swift/swift-goof',
+  dependencies: [
+    {
+      identity: 'apple.swift-argument-parser',
+      name: 'swift-argument-parser',
+      url: 'apple.swift-argument-parser',
+      version: '1.2.0',
+      path: '/Users/user/swift/swift-goof/.build/checkouts/swift-argument-parser',
+      dependencies: [],
+    },
+    {
+      identity: 'apple.swift-nio',
+      name: 'swift-nio',
+      url: 'apple.swift-nio',
+      version: '2.42.0',
+      path: '/Users/user/swift/swift-goof/.build/checkouts/swift-nio',
+      dependencies: [
+        {
+          identity: 'apple.swift-atomics',
+          name: 'swift-atomics',
+          url: 'apple.swift-atomics',
+          version: '1.0.2',
+          path: '/Users/user/swift/swift-goof/.build/checkouts/swift-atomics',
+          dependencies: [],
+        },
+      ],
+    },
+  ],
+};
+
 export const dependencies = {
   identity: 'swift-goof',
   name: 'swiftPM-spike',

--- a/test/unit/__snapshots__/compute-depgraph.spec.ts.snap
+++ b/test/unit/__snapshots__/compute-depgraph.spec.ts.snap
@@ -75,6 +75,65 @@ exports[`compute-depgraph should convert registry identity URLs (scope.package-n
 }
 `;
 
+exports[`compute-depgraph should handle trees mixing https URLs and registry identities 1`] = `
+{
+  "graph": {
+    "nodes": [
+      {
+        "deps": [
+          {
+            "nodeId": "github.com/grpc/grpc-swift@1.11.0",
+          },
+          {
+            "nodeId": "github.com/apple/swift-argument-parser@1.2.0",
+          },
+        ],
+        "nodeId": "root-node",
+        "pkgId": "swiftPM-spike@unspecified",
+      },
+      {
+        "deps": [],
+        "nodeId": "github.com/grpc/grpc-swift@1.11.0",
+        "pkgId": "github.com/grpc/grpc-swift@1.11.0",
+      },
+      {
+        "deps": [],
+        "nodeId": "github.com/apple/swift-argument-parser@1.2.0",
+        "pkgId": "github.com/apple/swift-argument-parser@1.2.0",
+      },
+    ],
+    "rootNodeId": "root-node",
+  },
+  "pkgManager": {
+    "name": "swift",
+  },
+  "pkgs": [
+    {
+      "id": "swiftPM-spike@unspecified",
+      "info": {
+        "name": "swiftPM-spike",
+        "version": "unspecified",
+      },
+    },
+    {
+      "id": "github.com/grpc/grpc-swift@1.11.0",
+      "info": {
+        "name": "github.com/grpc/grpc-swift",
+        "version": "1.11.0",
+      },
+    },
+    {
+      "id": "github.com/apple/swift-argument-parser@1.2.0",
+      "info": {
+        "name": "github.com/apple/swift-argument-parser",
+        "version": "1.2.0",
+      },
+    },
+  ],
+  "schemaVersion": "1.3.0",
+}
+`;
+
 exports[`compute-depgraph should successfully create snyk dep graph from swift-pm dep tree 1`] = `
 {
   "graph": {

--- a/test/unit/__snapshots__/compute-depgraph.spec.ts.snap
+++ b/test/unit/__snapshots__/compute-depgraph.spec.ts.snap
@@ -1,5 +1,80 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`compute-depgraph should convert registry identity URLs (scope.package-name) to github.com paths 1`] = `
+{
+  "graph": {
+    "nodes": [
+      {
+        "deps": [
+          {
+            "nodeId": "github.com/apple/swift-argument-parser@1.2.0",
+          },
+          {
+            "nodeId": "github.com/apple/swift-nio@2.42.0",
+          },
+        ],
+        "nodeId": "root-node",
+        "pkgId": "swiftPM-spike@unspecified",
+      },
+      {
+        "deps": [],
+        "nodeId": "github.com/apple/swift-argument-parser@1.2.0",
+        "pkgId": "github.com/apple/swift-argument-parser@1.2.0",
+      },
+      {
+        "deps": [
+          {
+            "nodeId": "github.com/apple/swift-atomics@1.0.2",
+          },
+        ],
+        "nodeId": "github.com/apple/swift-nio@2.42.0",
+        "pkgId": "github.com/apple/swift-nio@2.42.0",
+      },
+      {
+        "deps": [],
+        "nodeId": "github.com/apple/swift-atomics@1.0.2",
+        "pkgId": "github.com/apple/swift-atomics@1.0.2",
+      },
+    ],
+    "rootNodeId": "root-node",
+  },
+  "pkgManager": {
+    "name": "swift",
+  },
+  "pkgs": [
+    {
+      "id": "swiftPM-spike@unspecified",
+      "info": {
+        "name": "swiftPM-spike",
+        "version": "unspecified",
+      },
+    },
+    {
+      "id": "github.com/apple/swift-argument-parser@1.2.0",
+      "info": {
+        "name": "github.com/apple/swift-argument-parser",
+        "version": "1.2.0",
+      },
+    },
+    {
+      "id": "github.com/apple/swift-nio@2.42.0",
+      "info": {
+        "name": "github.com/apple/swift-nio",
+        "version": "2.42.0",
+      },
+    },
+    {
+      "id": "github.com/apple/swift-atomics@1.0.2",
+      "info": {
+        "name": "github.com/apple/swift-atomics",
+        "version": "1.0.2",
+      },
+    },
+  ],
+  "schemaVersion": "1.3.0",
+}
+`;
+
 exports[`compute-depgraph should successfully create snyk dep graph from swift-pm dep tree 1`] = `
 {
   "graph": {

--- a/test/unit/compute-depgraph.spec.ts
+++ b/test/unit/compute-depgraph.spec.ts
@@ -1,6 +1,9 @@
 import { computeDepGraph } from '../../lib/compute-depgraph';
 import { execute } from '../../lib/subprocess';
-import { dependencies } from '../fixtures/dependencies';
+import {
+  dependencies,
+  dependenciesWithRegistryIdentity,
+} from '../fixtures/dependencies';
 import * as path from 'path';
 
 jest.setTimeout(100000);
@@ -22,6 +25,18 @@ describe('compute-depgraph', () => {
       targetFile,
     );
 
+    expect(result).toMatchSnapshot();
+  });
+
+  it('should convert registry identity URLs (scope.package-name) to github.com paths', async () => {
+    mockedExecute.mockResolvedValueOnce(
+      JSON.stringify(dependenciesWithRegistryIdentity),
+    );
+    const targetFile = path.join(__dirname, '../fixtures/Package.swift');
+    const result = await computeDepGraph(
+      path.join(__dirname, '../fixtures'),
+      targetFile,
+    );
     expect(result).toMatchSnapshot();
   });
 

--- a/test/unit/compute-depgraph.spec.ts
+++ b/test/unit/compute-depgraph.spec.ts
@@ -50,7 +50,13 @@ describe('packageNameFromUrl', () => {
     );
   });
 
-  it('returns SSH URLs unchanged (pre-existing limitation)', () => {
+  it('returns ssh:// URLs unchanged (pre-existing limitation)', () => {
+    expect(packageNameFromUrl('ssh://git@github.com/apple/swift-nio.git')).toBe(
+      'ssh://git@github.com/apple/swift-nio.git',
+    );
+  });
+
+  it('returns git@ URLs unchanged (pre-existing limitation)', () => {
     expect(packageNameFromUrl('git@github.com:apple/swift-nio.git')).toBe(
       'git@github.com:apple/swift-nio.git',
     );

--- a/test/unit/compute-depgraph.spec.ts
+++ b/test/unit/compute-depgraph.spec.ts
@@ -1,7 +1,8 @@
-import { computeDepGraph } from '../../lib/compute-depgraph';
+import { computeDepGraph, packageNameFromUrl } from '../../lib/compute-depgraph';
 import { execute } from '../../lib/subprocess';
 import {
   dependencies,
+  dependenciesWithMixedSources,
   dependenciesWithRegistryIdentity,
 } from '../fixtures/dependencies';
 import * as path from 'path';
@@ -13,6 +14,54 @@ jest.mock('fs');
 const mockedExecute = jest.mocked(execute);
 mockedExecute.mockResolvedValue(JSON.stringify(dependencies));
 const SWIFT_DEFAULT_PARAMETERS_COUNT = 6;
+
+describe('packageNameFromUrl', () => {
+  it('strips https scheme and .git suffix from SCM URLs', () => {
+    expect(packageNameFromUrl('https://github.com/apple/swift-nio.git')).toBe(
+      'github.com/apple/swift-nio',
+    );
+  });
+
+  it('strips http scheme and .git suffix', () => {
+    expect(packageNameFromUrl('http://github.com/apple/swift-nio.git')).toBe(
+      'github.com/apple/swift-nio',
+    );
+  });
+
+  it('only strips .git at end of string, not mid-URL occurrences', () => {
+    expect(
+      packageNameFromUrl('https://github.com/user/digit-tool.git'),
+    ).toBe('github.com/user/digit-tool');
+  });
+
+  it('converts scope.package-name registry identity to github.com path', () => {
+    expect(packageNameFromUrl('apple.swift-argument-parser')).toBe(
+      'github.com/apple/swift-argument-parser',
+    );
+  });
+
+  it('returns single-component identities (no dot) unchanged', () => {
+    expect(packageNameFromUrl('swift-nio')).toBe('swift-nio');
+  });
+
+  it('returns multi-dot strings unchanged (not valid Swift registry format)', () => {
+    expect(packageNameFromUrl('com.apple.swift-nio')).toBe(
+      'com.apple.swift-nio',
+    );
+  });
+
+  it('returns SSH URLs unchanged (pre-existing limitation)', () => {
+    expect(packageNameFromUrl('git@github.com:apple/swift-nio.git')).toBe(
+      'git@github.com:apple/swift-nio.git',
+    );
+  });
+
+  it('returns local paths unchanged', () => {
+    expect(packageNameFromUrl('/Users/user/my-package')).toBe(
+      '/Users/user/my-package',
+    );
+  });
+});
 
 describe('compute-depgraph', () => {
   beforeEach(() => {
@@ -31,6 +80,18 @@ describe('compute-depgraph', () => {
   it('should convert registry identity URLs (scope.package-name) to github.com paths', async () => {
     mockedExecute.mockResolvedValueOnce(
       JSON.stringify(dependenciesWithRegistryIdentity),
+    );
+    const targetFile = path.join(__dirname, '../fixtures/Package.swift');
+    const result = await computeDepGraph(
+      path.join(__dirname, '../fixtures'),
+      targetFile,
+    );
+    expect(result).toMatchSnapshot();
+  });
+
+  it('should handle trees mixing https URLs and registry identities', async () => {
+    mockedExecute.mockResolvedValueOnce(
+      JSON.stringify(dependenciesWithMixedSources),
     );
     const targetFile = path.join(__dirname, '../fixtures/Package.swift');
     const result = await computeDepGraph(


### PR DESCRIPTION
## Summary

- When `--replace-scm-with-registry` is in use, Swift sets the `url` field to a registry identity (e.g. `apple.swift-argument-parser`) rather than the SCM URL
- The previous logic stripped `https://` and `.git` — leaving `apple.swift-argument-parser` unchanged, which produces no vuln DB hit
- This PR extracts a `packageNameFromUrl` helper that detects `scope.package-name` format and maps it to `github.com/scope/package-name` before building the dep-graph

## Root cause

`traverseTree` in `compute-depgraph.ts` derived package names solely by stripping URL scheme and `.git` suffix. Registry identities have neither, so they passed through untransformed.

## Changes

- `lib/compute-depgraph.ts` — fix unescaped `.git` regex (`/.git/g` → `/\.git$/g`); new exported `packageNameFromUrl` helper with three cases: https/http URL (existing behaviour), registry identity (`scope.package-name` → `github.com/scope/package-name`), and local paths/SSH URLs (returned as-is)
- `test/fixtures/dependencies.ts` — new `dependenciesWithRegistryIdentity` and `dependenciesWithMixedSources` fixtures
- `test/unit/compute-depgraph.spec.ts` — direct unit tests for all `packageNameFromUrl` edge cases (https, http, registry identity, single-component, multi-dot, ssh://, git@, local path); mixed-tree integration test
- `test/unit/__snapshots__/compute-depgraph.spec.ts.snap` — snapshots for new tree tests

## Test plan

- [ ] `npx jest test/unit` — all 18 tests pass
- [ ] Manually verify with a project using `--replace-scm-with-registry` that registry-sourced packages now appear in vuln results

Fixes OSM-3567

🤖 Generated with [Claude Code](https://claude.com/claude-code)